### PR TITLE
Run functional test without `subprocess`

### DIFF
--- a/tests/functional_tests/test_store_functional.py
+++ b/tests/functional_tests/test_store_functional.py
@@ -1,16 +1,16 @@
 """Functional tests for the base Store class."""
 
-import subprocess
 
-
-def test_main_script_runs():
+def test_main_script_runs(capsys):
     """Comprobar cómo interactúan varios componentes del sistema entre sí.
 
     Por ejemplo, se podría probar cómo una tienda maneja múltiples tipos de
     muebles con operaciones encadenadas.
     """
-    result = subprocess.run(['python3', 'main.py'], capture_output=True,
-                            text=True)
-    assert 'Initial inventory' in result.stdout
-    assert 'Selling item 2' in result.stdout
-    assert result.returncode == 0
+    import main
+
+    main.main()
+
+    captured = capsys.readouterr()
+    assert 'Initial inventory' in captured.out
+    assert 'Selling item 2' in captured.out


### PR DESCRIPTION
@fmrico I happened to see this neat introduction repo and have a minor suggestion, based on:

https://docs.pytest.org/en/stable/how-to/capture-stdout-stderr.html#accessing-captured-output-from-a-test-function

It also acts as a lesson for why writing code like this makes sense:

```python
if __name__ == '__main__':
    main()
```

Feel free to take it or leave it!